### PR TITLE
Some Debian packaging tricks

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,3 +11,4 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, qtdeclarative5-particles-plugin, plasma-workspace,
          qtdeclarative5-folderlistmodel-plugin
 Description: Live snow wallpaper for plasma 5
+ KDE plasma 5 live wallpaper snow;

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), cmake, pkg-kde-tools (>= 0.15.15ubuntu1~), extr
 Standards-Version: 3.9.5
 
 Package: plasma-wallpaper-snow
-Architecture: any
+Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, qtdeclarative5-particles-plugin, plasma-workspace,
          qtdeclarative5-folderlistmodel-plugin
 Description: Live snow wallpaper for plasma 5


### PR DESCRIPTION
- "Architecture" should be "all" for packages that doesn't provide any binaries.
- extended-description-is-empty packaging error was resolved.
